### PR TITLE
add access to rules by exposing the translator Rule instance

### DIFF
--- a/datetime.go
+++ b/datetime.go
@@ -87,37 +87,37 @@ func (t *Translator) FormatDateTime(format int, datetime time.Time) (string, err
 	pattern := ""
 	switch format {
 	case DateFormatFull:
-		pattern = t.rules.DateTime.Formats.Date.Full
+		pattern = t.Rules.DateTime.Formats.Date.Full
 	case DateFormatLong:
-		pattern = t.rules.DateTime.Formats.Date.Long
+		pattern = t.Rules.DateTime.Formats.Date.Long
 	case DateFormatMedium:
-		pattern = t.rules.DateTime.Formats.Date.Medium
+		pattern = t.Rules.DateTime.Formats.Date.Medium
 	case DateFormatShort:
-		pattern = t.rules.DateTime.Formats.Date.Short
+		pattern = t.Rules.DateTime.Formats.Date.Short
 	case TimeFormatFull:
-		pattern = t.rules.DateTime.Formats.Time.Full
+		pattern = t.Rules.DateTime.Formats.Time.Full
 	case TimeFormatLong:
-		pattern = t.rules.DateTime.Formats.Time.Long
+		pattern = t.Rules.DateTime.Formats.Time.Long
 	case TimeFormatMedium:
-		pattern = t.rules.DateTime.Formats.Time.Medium
+		pattern = t.Rules.DateTime.Formats.Time.Medium
 	case TimeFormatShort:
-		pattern = t.rules.DateTime.Formats.Time.Short
+		pattern = t.Rules.DateTime.Formats.Time.Short
 	case DateTimeFormatFull:
-		datePattern := strings.Trim(t.rules.DateTime.Formats.Date.Full, " ,")
-		timePattern := strings.Trim(t.rules.DateTime.Formats.Time.Full, " ,")
-		pattern = getDateTimePattern(t.rules.DateTime.Formats.DateTime.Full, datePattern, timePattern)
+		datePattern := strings.Trim(t.Rules.DateTime.Formats.Date.Full, " ,")
+		timePattern := strings.Trim(t.Rules.DateTime.Formats.Time.Full, " ,")
+		pattern = getDateTimePattern(t.Rules.DateTime.Formats.DateTime.Full, datePattern, timePattern)
 	case DateTimeFormatLong:
-		datePattern := strings.Trim(t.rules.DateTime.Formats.Date.Long, " ,")
-		timePattern := strings.Trim(t.rules.DateTime.Formats.Time.Long, " ,")
-		pattern = getDateTimePattern(t.rules.DateTime.Formats.DateTime.Long, datePattern, timePattern)
+		datePattern := strings.Trim(t.Rules.DateTime.Formats.Date.Long, " ,")
+		timePattern := strings.Trim(t.Rules.DateTime.Formats.Time.Long, " ,")
+		pattern = getDateTimePattern(t.Rules.DateTime.Formats.DateTime.Long, datePattern, timePattern)
 	case DateTimeFormatMedium:
-		datePattern := strings.Trim(t.rules.DateTime.Formats.Date.Medium, " ,")
-		timePattern := strings.Trim(t.rules.DateTime.Formats.Time.Medium, " ,")
-		pattern = getDateTimePattern(t.rules.DateTime.Formats.DateTime.Medium, datePattern, timePattern)
+		datePattern := strings.Trim(t.Rules.DateTime.Formats.Date.Medium, " ,")
+		timePattern := strings.Trim(t.Rules.DateTime.Formats.Time.Medium, " ,")
+		pattern = getDateTimePattern(t.Rules.DateTime.Formats.DateTime.Medium, datePattern, timePattern)
 	case DateTimeFormatShort:
-		datePattern := strings.Trim(t.rules.DateTime.Formats.Date.Short, " ,")
-		timePattern := strings.Trim(t.rules.DateTime.Formats.Time.Short, " ,")
-		pattern = getDateTimePattern(t.rules.DateTime.Formats.DateTime.Short, datePattern, timePattern)
+		datePattern := strings.Trim(t.Rules.DateTime.Formats.Date.Short, " ,")
+		timePattern := strings.Trim(t.Rules.DateTime.Formats.Time.Short, " ,")
+		pattern = getDateTimePattern(t.Rules.DateTime.Formats.DateTime.Short, datePattern, timePattern)
 	default:
 		return "", translatorError{message: "unknown datetime format" + pattern[0:1]}
 	}
@@ -264,29 +264,29 @@ func (t *Translator) formatDateTimeComponentMonth2Plus(month int) string {
 func (t *Translator) formatDateTimeComponentMonthAbbreviated(month int) string {
 	switch month {
 	case 1:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month1
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month1
 	case 2:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month2
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month2
 	case 3:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month3
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month3
 	case 4:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month4
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month4
 	case 5:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month5
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month5
 	case 6:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month6
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month6
 	case 7:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month7
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month7
 	case 8:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month8
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month8
 	case 9:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month9
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month9
 	case 10:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month10
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month10
 	case 11:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month11
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month11
 	case 12:
-		return t.rules.DateTime.FormatNames.Months.Abbreviated.Month12
+		return t.Rules.DateTime.FormatNames.Months.Abbreviated.Month12
 	}
 
 	return ""
@@ -296,29 +296,29 @@ func (t *Translator) formatDateTimeComponentMonthAbbreviated(month int) string {
 func (t *Translator) formatDateTimeComponentMonthWide(month int) string {
 	switch month {
 	case 1:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month1
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month1
 	case 2:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month2
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month2
 	case 3:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month3
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month3
 	case 4:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month4
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month4
 	case 5:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month5
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month5
 	case 6:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month6
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month6
 	case 7:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month7
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month7
 	case 8:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month8
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month8
 	case 9:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month9
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month9
 	case 10:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month10
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month10
 	case 11:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month11
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month11
 	case 12:
-		return t.rules.DateTime.FormatNames.Months.Wide.Month12
+		return t.Rules.DateTime.FormatNames.Months.Wide.Month12
 	}
 
 	return ""
@@ -329,29 +329,29 @@ func (t *Translator) formatDateTimeComponentMonthWide(month int) string {
 func (t *Translator) formatDateTimeComponentMonthNarrow(month int) string {
 	switch month {
 	case 1:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month1
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month1
 	case 2:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month2
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month2
 	case 3:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month3
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month3
 	case 4:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month4
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month4
 	case 5:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month5
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month5
 	case 6:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month6
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month6
 	case 7:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month7
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month7
 	case 8:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month8
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month8
 	case 9:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month9
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month9
 	case 10:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month10
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month10
 	case 11:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month11
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month11
 	case 12:
-		return t.rules.DateTime.FormatNames.Months.Narrow.Month12
+		return t.Rules.DateTime.FormatNames.Months.Narrow.Month12
 	}
 
 	return ""
@@ -380,19 +380,19 @@ func (t *Translator) formatDateTimeComponentDayOfWeek(datetime time.Time, length
 func (t *Translator) formatDateTimeComponentDayOfWeekAbbreviated(dayOfWeek time.Weekday) string {
 	switch dayOfWeek {
 	case time.Sunday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Sun
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Sun
 	case time.Monday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Mon
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Mon
 	case time.Tuesday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Tue
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Tue
 	case time.Wednesday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Wed
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Wed
 	case time.Thursday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Thu
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Thu
 	case time.Friday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Fri
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Fri
 	case time.Saturday:
-		return t.rules.DateTime.FormatNames.Days.Abbreviated.Sat
+		return t.Rules.DateTime.FormatNames.Days.Abbreviated.Sat
 	}
 
 	return ""
@@ -403,19 +403,19 @@ func (t *Translator) formatDateTimeComponentDayOfWeekAbbreviated(dayOfWeek time.
 func (t *Translator) formatDateTimeComponentDayOfWeekShort(dayOfWeek time.Weekday) string {
 	switch dayOfWeek {
 	case time.Sunday:
-		return t.rules.DateTime.FormatNames.Days.Short.Sun
+		return t.Rules.DateTime.FormatNames.Days.Short.Sun
 	case time.Monday:
-		return t.rules.DateTime.FormatNames.Days.Short.Mon
+		return t.Rules.DateTime.FormatNames.Days.Short.Mon
 	case time.Tuesday:
-		return t.rules.DateTime.FormatNames.Days.Short.Tue
+		return t.Rules.DateTime.FormatNames.Days.Short.Tue
 	case time.Wednesday:
-		return t.rules.DateTime.FormatNames.Days.Short.Wed
+		return t.Rules.DateTime.FormatNames.Days.Short.Wed
 	case time.Thursday:
-		return t.rules.DateTime.FormatNames.Days.Short.Thu
+		return t.Rules.DateTime.FormatNames.Days.Short.Thu
 	case time.Friday:
-		return t.rules.DateTime.FormatNames.Days.Short.Fri
+		return t.Rules.DateTime.FormatNames.Days.Short.Fri
 	case time.Saturday:
-		return t.rules.DateTime.FormatNames.Days.Short.Sat
+		return t.Rules.DateTime.FormatNames.Days.Short.Sat
 	}
 
 	return ""
@@ -426,19 +426,19 @@ func (t *Translator) formatDateTimeComponentDayOfWeekShort(dayOfWeek time.Weekda
 func (t *Translator) formatDateTimeComponentDayOfWeekWide(dayOfWeek time.Weekday) string {
 	switch dayOfWeek {
 	case time.Sunday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Sun
+		return t.Rules.DateTime.FormatNames.Days.Wide.Sun
 	case time.Monday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Mon
+		return t.Rules.DateTime.FormatNames.Days.Wide.Mon
 	case time.Tuesday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Tue
+		return t.Rules.DateTime.FormatNames.Days.Wide.Tue
 	case time.Wednesday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Wed
+		return t.Rules.DateTime.FormatNames.Days.Wide.Wed
 	case time.Thursday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Thu
+		return t.Rules.DateTime.FormatNames.Days.Wide.Thu
 	case time.Friday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Fri
+		return t.Rules.DateTime.FormatNames.Days.Wide.Fri
 	case time.Saturday:
-		return t.rules.DateTime.FormatNames.Days.Wide.Sat
+		return t.Rules.DateTime.FormatNames.Days.Wide.Sat
 	}
 
 	return ""
@@ -449,19 +449,19 @@ func (t *Translator) formatDateTimeComponentDayOfWeekWide(dayOfWeek time.Weekday
 func (t *Translator) formatDateTimeComponentDayOfWeekNarrow(dayOfWeek time.Weekday) string {
 	switch dayOfWeek {
 	case time.Sunday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Sun
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Sun
 	case time.Monday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Mon
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Mon
 	case time.Tuesday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Tue
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Tue
 	case time.Wednesday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Wed
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Wed
 	case time.Thursday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Thu
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Thu
 	case time.Friday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Fri
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Fri
 	case time.Saturday:
-		return t.rules.DateTime.FormatNames.Days.Narrow.Sat
+		return t.Rules.DateTime.FormatNames.Days.Narrow.Sat
 	}
 
 	return ""
@@ -579,28 +579,28 @@ func (t *Translator) formatDateTimeComponentPeriod(datetime time.Time, length in
 // component.
 func (t *Translator) formatDateTimeComponentPeriodAbbreviated(hour int) string {
 	if hour < 12 {
-		return t.rules.DateTime.FormatNames.Periods.Abbreviated.AM
+		return t.Rules.DateTime.FormatNames.Periods.Abbreviated.AM
 	}
 
-	return t.rules.DateTime.FormatNames.Periods.Abbreviated.PM
+	return t.Rules.DateTime.FormatNames.Periods.Abbreviated.PM
 }
 
 // formatDateTimeComponentPeriodWide renders a full period component.
 func (t *Translator) formatDateTimeComponentPeriodWide(hour int) string {
 	if hour < 12 {
-		return t.rules.DateTime.FormatNames.Periods.Wide.AM
+		return t.Rules.DateTime.FormatNames.Periods.Wide.AM
 	}
 
-	return t.rules.DateTime.FormatNames.Periods.Wide.PM
+	return t.Rules.DateTime.FormatNames.Periods.Wide.PM
 }
 
 // formatDateTimeComponentPeriodNarrow renders a super-short period component.
 func (t *Translator) formatDateTimeComponentPeriodNarrow(hour int) string {
 	if hour < 12 {
-		return t.rules.DateTime.FormatNames.Periods.Narrow.AM
+		return t.Rules.DateTime.FormatNames.Periods.Narrow.AM
 	}
 
-	return t.rules.DateTime.FormatNames.Periods.Narrow.PM
+	return t.Rules.DateTime.FormatNames.Periods.Narrow.PM
 }
 
 // formatDateTimeComponentQuarter renders a calendar quarter component - this
@@ -685,7 +685,7 @@ func (t *Translator) parseDateTimeFormat(pattern string) ([]*datetimePatternComp
 		}
 		if char == string(datetimeFormatTimeSeparator) {
 			component := &datetimePatternComponent{
-				pattern:       t.rules.DateTime.TimeSeparator,
+				pattern:       t.Rules.DateTime.TimeSeparator,
 				componentType: datetimePatternComponentLiteral,
 			}
 			format = append(format, component)

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -1,9 +1,10 @@
 package i18n
 
 import (
+	"log"
 	"time"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 var (
@@ -282,6 +283,9 @@ func (s *MySuite) TestFormatDateTime(c *C) {
 
 	for locale, expected := range locales {
 		t, _ := f.GetTranslator(locale)
+
+		log.Println(t.Rules.DateTime.FormatNames.Days.Wide.Fri)
+
 		d, err := t.FormatDateTime(DateFormatShort, datetime)
 
 		if d != expected {
@@ -295,13 +299,13 @@ func (s *MySuite) TestFormatDateTime(c *C) {
 	// test the private method
 	checkAll := "G y yy yyyy M MM MMM MMMM MMMMM E EE EEE EEEE EEEEE d dd h hh H HH m mm s ss a aaa aaaa aaaaa Q z v 'literal':'literal'   ,   "
 	shouldMatch := "2006 06 2006 1 01 Jan January J Monday Mo Mon Monday M 2 02 3 03 15 15 4 04 5 05 PM PM PM p    literal#literal"
-	separator := tEn.rules.DateTime.TimeSeparator
-	tEn.rules.DateTime.TimeSeparator = "#"
+	separator := tEn.Rules.DateTime.TimeSeparator
+	tEn.Rules.DateTime.TimeSeparator = "#"
 	patternToCheckEverything, _ := tEn.parseDateTimeFormat(checkAll)
-	tEn.rules.DateTime.TimeSeparator = separator
+	tEn.Rules.DateTime.TimeSeparator = separator
 
 	custom, err := tEn.formatDateTime(datetime, patternToCheckEverything)
-	tEn.rules.DateTime.TimeSeparator = separator
+	tEn.Rules.DateTime.TimeSeparator = separator
 
 	c.Check(err, IsNil)
 
@@ -443,12 +447,12 @@ func (s *MySuite) TestFormatDateTimeComponent(c *C) {
 	_, err = tEn.formatDateTimeComponent(datetime, "ssssss")
 	c.Check(err, NotNil)
 
-	abbr := tEn.rules.DateTime.FormatNames.Periods.Abbreviated.PM
-	narrow := tEn.rules.DateTime.FormatNames.Periods.Narrow.PM
-	wide := tEn.rules.DateTime.FormatNames.Periods.Wide.PM
-	tEn.rules.DateTime.FormatNames.Periods.Abbreviated.PM = "abbr"
-	tEn.rules.DateTime.FormatNames.Periods.Narrow.PM = "narrow"
-	tEn.rules.DateTime.FormatNames.Periods.Wide.PM = "wide"
+	abbr := tEn.Rules.DateTime.FormatNames.Periods.Abbreviated.PM
+	narrow := tEn.Rules.DateTime.FormatNames.Periods.Narrow.PM
+	wide := tEn.Rules.DateTime.FormatNames.Periods.Wide.PM
+	tEn.Rules.DateTime.FormatNames.Periods.Abbreviated.PM = "abbr"
+	tEn.Rules.DateTime.FormatNames.Periods.Narrow.PM = "narrow"
+	tEn.Rules.DateTime.FormatNames.Periods.Wide.PM = "wide"
 	str, err = tEn.formatDateTimeComponent(datetime, "a")
 	c.Check(err, IsNil)
 	c.Check(str, Equals, "wide")
@@ -461,9 +465,9 @@ func (s *MySuite) TestFormatDateTimeComponent(c *C) {
 	str, err = tEn.formatDateTimeComponent(datetime, "aaaaa")
 	c.Check(err, IsNil)
 	c.Check(str, Equals, "narrow")
-	tEn.rules.DateTime.FormatNames.Periods.Abbreviated.PM = abbr
-	tEn.rules.DateTime.FormatNames.Periods.Narrow.PM = narrow
-	tEn.rules.DateTime.FormatNames.Periods.Wide.PM = wide
+	tEn.Rules.DateTime.FormatNames.Periods.Abbreviated.PM = abbr
+	tEn.Rules.DateTime.FormatNames.Periods.Narrow.PM = narrow
+	tEn.Rules.DateTime.FormatNames.Periods.Wide.PM = wide
 
 	_, err = tEn.formatDateTimeComponent(datetime, "aaaaaa")
 	c.Check(err, NotNil)

--- a/i18n.go
+++ b/i18n.go
@@ -29,7 +29,7 @@ type TranslatorFactory struct {
 type Translator struct {
 	messages map[string]string
 	locale   string
-	rules    *translatorRules
+	Rules    *translatorRules
 	fallback *Translator
 }
 
@@ -236,7 +236,7 @@ func (f *TranslatorFactory) GetTranslator(localeCode string) (t *Translator, err
 	t.locale = localeCode
 	t.messages = messages
 	t.fallback = fallback
-	t.rules = rules
+	t.Rules = rules
 
 	f.translators[localeCode] = t
 
@@ -343,7 +343,7 @@ func (t *Translator) Pluralize(key string, number float64, numberStr string) (tr
 		return
 	}
 
-	form := (t.rules.PluralRuleFunc)(number)
+	form := (t.Rules.PluralRuleFunc)(number)
 
 	parts := strings.Split(t.messages[key], "|")
 
@@ -362,7 +362,7 @@ func (t *Translator) Pluralize(key string, number float64, numberStr string) (tr
 
 // Direction returns the text directionality of the locale's writing system
 func (t *Translator) Direction() (direction string) {
-	return t.rules.Direction
+	return t.Rules.Direction
 }
 
 // substitute returns a string copy of the input str string will all keys in the

--- a/i18n_test.go
+++ b/i18n_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 // passes control of tests off to go-check
@@ -203,7 +203,7 @@ func (s *MySuite) TestGetTranslator(c *C) {
 	c.Check(errors, HasLen, 0)
 	c.Check(tEn.messages, Not(HasLen), 0)
 	c.Check(tEn.locale, Equals, "en")
-	c.Check(tEn.rules, NotNil)
+	c.Check(tEn.Rules, NotNil)
 	c.Check(tEn.fallback, IsNil)
 
 	tFr, errors := f.GetTranslator("fr")
@@ -212,7 +212,7 @@ func (s *MySuite) TestGetTranslator(c *C) {
 	c.Check(errors, HasLen, 0)
 	c.Check(tFr.messages, Not(HasLen), 0)
 	c.Check(tFr.locale, Equals, "fr")
-	c.Check(tFr.rules, NotNil)
+	c.Check(tFr.Rules, NotNil)
 	c.Assert(tFr.fallback, NotNil)
 	c.Check(tFr.fallback, Equals, tEn)
 

--- a/numbers.go
+++ b/numbers.go
@@ -44,10 +44,10 @@ var (
 // instead. If the currency key requested is not recognized, it is used as the
 // symbol, and an error is returned with the formatted string.
 func (t *Translator) FormatCurrency(number float64, currency string) (formatted string, err error) {
-	format := t.parseFormat(t.rules.Numbers.Formats.Currency, true)
+	format := t.parseFormat(t.Rules.Numbers.Formats.Currency, true)
 	result := t.formatNumber(format, number)
 	symbol := currency
-	if c, ok := t.rules.Currencies[currency]; ok {
+	if c, ok := t.Rules.Currencies[currency]; ok {
 		symbol = c.Symbol
 	} else {
 		err = translatorError{translator: t, message: "unknown currency: " + currency}
@@ -59,11 +59,11 @@ func (t *Translator) FormatCurrency(number float64, currency string) (formatted 
 // FormatCurrencyWhole does exactly what FormatCurrency does, but it leaves off
 // any decimal places. AKA, it would return $100 rather than $100.00.
 func (t *Translator) FormatCurrencyWhole(number float64, currency string) (formatted string, err error) {
-	format := t.parseFormat(t.rules.Numbers.Formats.Currency, false)
+	format := t.parseFormat(t.Rules.Numbers.Formats.Currency, false)
 
 	result := t.formatNumber(format, number)
 	symbol := currency
-	if c, ok := t.rules.Currencies[currency]; ok {
+	if c, ok := t.Rules.Currencies[currency]; ok {
 		symbol = c.Symbol
 	} else {
 		err = translatorError{translator: t, message: "unknown currency: " + currency}
@@ -75,20 +75,20 @@ func (t *Translator) FormatCurrencyWhole(number float64, currency string) (forma
 // FormatNumber takes a float number and returns a properly formatted string
 // representation of that number according to the locale's number format.
 func (t *Translator) FormatNumber(number float64) string {
-	return t.formatNumber(t.parseFormat(t.rules.Numbers.Formats.Decimal, true), number)
+	return t.formatNumber(t.parseFormat(t.Rules.Numbers.Formats.Decimal, true), number)
 }
 
 // FormatNumberWhole does exactly what FormatNumber does, but it leaves off any
 // decimal places. AKA, it would return 100 rather than 100.01.
 func (t *Translator) FormatNumberWhole(number float64) string {
-	return t.formatNumber(t.parseFormat(t.rules.Numbers.Formats.Decimal, false), number)
+	return t.formatNumber(t.parseFormat(t.Rules.Numbers.Formats.Decimal, false), number)
 }
 
 // FormatPercent takes a float number and returns a properly formatted string
 // representation of that number as a percentage according to the locale's
 // percentage format.
 func (t *Translator) FormatPercent(number float64) string {
-	return t.formatNumber(t.parseFormat(t.rules.Numbers.Formats.Percent, true), number)
+	return t.formatNumber(t.parseFormat(t.Rules.Numbers.Formats.Percent, true), number)
 }
 
 // parseFormat takes a format string and returns a numberFormat instance
@@ -117,7 +117,7 @@ func (t *Translator) parseFormat(pattern string, includeDecimalDigits bool) *num
 		}
 
 		// default values for negative prefix & suffix
-		format.negativePrefix = string(t.rules.Numbers.Symbols.Negative) + string(format.positivePrefix)
+		format.negativePrefix = string(t.Rules.Numbers.Symbols.Negative) + string(format.positivePrefix)
 		format.negativeSuffix = format.positiveSuffix
 
 		// see if they are in the pattern
@@ -234,7 +234,7 @@ func (t *Translator) formatNumber(format *numberFormat, number float64) string {
 
 	// if there's a decimal portion, prepend the decimal point symbol
 	if len(decimal) > 0 {
-		decimal = string(t.rules.Numbers.Symbols.Decimal) + decimal
+		decimal = string(t.Rules.Numbers.Symbols.Decimal) + decimal
 	}
 
 	// put the integer portion into properly sized groups
@@ -242,7 +242,7 @@ func (t *Translator) formatNumber(format *numberFormat, number float64) string {
 		if len(integer) > format.groupSizeMain {
 			groupFinal := integer[len(integer)-format.groupSizeFinal:]
 			groupFirst := integer[:len(integer)-format.groupSizeFinal]
-			integer = strings.Join(chunkString(groupFirst, format.groupSizeMain), t.rules.Numbers.Symbols.Group) + t.rules.Numbers.Symbols.Group + groupFinal
+			integer = strings.Join(chunkString(groupFirst, format.groupSizeMain), t.Rules.Numbers.Symbols.Group) + t.Rules.Numbers.Symbols.Group + groupFinal
 		}
 	}
 
@@ -255,8 +255,8 @@ func (t *Translator) formatNumber(format *numberFormat, number float64) string {
 	}
 
 	// replace percents and permilles with the local symbols (likely to be exactly the same)
-	formatted = strings.Replace(formatted, "%", string(t.rules.Numbers.Symbols.Percent), -1)
-	formatted = strings.Replace(formatted, "‰", string(t.rules.Numbers.Symbols.Permille), -1)
+	formatted = strings.Replace(formatted, "%", string(t.Rules.Numbers.Symbols.Percent), -1)
+	formatted = strings.Replace(formatted, "‰", string(t.Rules.Numbers.Symbols.Permille), -1)
 
 	return formatted
 }

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestFormatCurrency(c *C) {
@@ -150,11 +150,11 @@ func (s *MySuite) TestFormatNumber(c *C) {
 		groupSizeMain:    3,
 	})
 
-	tEn.rules.Numbers.Symbols.Decimal = ".."
-	tEn.rules.Numbers.Symbols.Group = ",,"
-	tEn.rules.Numbers.Symbols.Negative = "--"
-	tEn.rules.Numbers.Symbols.Percent = "%%"
-	tEn.rules.Numbers.Symbols.Permille = "‰‰"
+	tEn.Rules.Numbers.Symbols.Decimal = ".."
+	tEn.Rules.Numbers.Symbols.Group = ",,"
+	tEn.Rules.Numbers.Symbols.Negative = "--"
+	tEn.Rules.Numbers.Symbols.Percent = "%%"
+	tEn.Rules.Numbers.Symbols.Permille = "‰‰"
 
 	// check numbers with too few integer digits & too many decimal digits
 	num = tEn.formatNumber(format, 1.12341234)
@@ -235,7 +235,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 1)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "")
@@ -248,7 +248,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 100)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "%")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "%")
@@ -261,7 +261,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 1000)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "‰")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "‰")
@@ -300,7 +300,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 5)
 	c.Check(format.minIntegerDigits, Equals, 5)
 	c.Check(format.multiplier, Equals, 1)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "")
@@ -313,7 +313,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 1)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "")
@@ -326,7 +326,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 1)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "")
@@ -339,7 +339,7 @@ func (s *MySuite) TestParseFormat(c *C) {
 	c.Check(format.minDecimalDigits, Equals, 0)
 	c.Check(format.minIntegerDigits, Equals, 1)
 	c.Check(format.multiplier, Equals, 1)
-	c.Check(format.negativePrefix, Equals, tEn.rules.Numbers.Symbols.Negative)
+	c.Check(format.negativePrefix, Equals, tEn.Rules.Numbers.Symbols.Negative)
 	c.Check(format.negativeSuffix, Equals, "")
 	c.Check(format.positivePrefix, Equals, "")
 	c.Check(format.positiveSuffix, Equals, "")

--- a/plurals_test.go
+++ b/plurals_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestIsInt(c *C) {

--- a/rules_test.go
+++ b/rules_test.go
@@ -3,7 +3,7 @@ package i18n
 import (
 	"reflect"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestLoad(c *C) {

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestLen(c *C) {


### PR DESCRIPTION
add access to rules by exposing the translator Rule instance, this
could potentially open up someone doing something stupid with
multithreading but is the most efficient way to expose the data.

example usage:

translator.Rules.DateTime.FormatNames.Days.Wide.Fri

issue-#6