### PR TITLE
Add method to Translator to return dereferenced Rules

### DIFF
--- a/datetime_test.go
+++ b/datetime_test.go
@@ -3,7 +3,7 @@ package i18n
 import (
 	"time"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 var (

--- a/i18n.go
+++ b/i18n.go
@@ -29,7 +29,7 @@ type TranslatorFactory struct {
 type Translator struct {
 	messages map[string]string
 	locale   string
-	rules    *translatorRules
+	rules    *TranslatorRules
 	fallback *Translator
 }
 
@@ -189,7 +189,7 @@ func (f *TranslatorFactory) GetTranslator(localeCode string) (t *Translator, err
 		errors = append(errors, e)
 	}
 
-	rules := new(translatorRules)
+	rules := new(TranslatorRules)
 	files := []string{}
 
 	// TODO: the rules loading logic is fairly complex, and there are some
@@ -358,6 +358,17 @@ func (t *Translator) Pluralize(key string, number float64, numberStr string) (tr
 		errors = append(errors, err)
 	}
 	return
+}
+
+// Translate returns the translated message, performang any substitutions
+// requested in the substitutions map. If neither this translator nor its
+// fallback translator (or the fallback's fallback and so on) have a translation
+// for the requested key, and empty string and an error will be returned.
+func (t *Translator) Rules() TranslatorRules {
+
+	rules := *t.rules
+
+	return rules
 }
 
 // Direction returns the text directionality of the locale's writing system

--- a/i18n_test.go
+++ b/i18n_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 // passes control of tests off to go-check

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestFormatCurrency(c *C) {

--- a/plurals_test.go
+++ b/plurals_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestIsInt(c *C) {

--- a/rules.go
+++ b/rules.go
@@ -16,9 +16,9 @@ const (
 	direction_rtl = "RTL"
 )
 
-// translatorRules is a struct containing all of the information unmarshalled
+// TranslatorRules is a struct containing all of the information unmarshalled
 // from a locale rules file.
-type translatorRules struct {
+type TranslatorRules struct {
 	Plural         string `yaml:"plural,omitempty"`
 	PluralRuleFunc pluralRule
 	Direction      string `yaml:"direction,omitempty"`
@@ -160,14 +160,14 @@ type translatorRules struct {
 	} `yaml:"datetime,omitempty"`
 }
 
-// currency is a struct that's used in the above translatorRules struct for
+// currency is a struct that's used in the above TranslatorRules struct for
 // capturing the rule info for a single currency
 type currency struct {
 	Symbol string `yaml:"symbol,omitempty"`
 }
 
 // load unmarshalls rule data from yaml files into the translator's rules
-func (t *translatorRules) load(files []string) (errors []error) {
+func (t *TranslatorRules) load(files []string) (errors []error) {
 
 	for _, file := range files {
 		_, statErr := os.Stat(file)
@@ -178,7 +178,7 @@ func (t *translatorRules) load(files []string) (errors []error) {
 				errors = append(errors, translatorError{message: "can't open rules file: " + readErr.Error()})
 			}
 
-			tNew := new(translatorRules)
+			tNew := new(TranslatorRules)
 			yamlErr := yaml.Unmarshal(contents, tNew)
 
 			if yamlErr != nil {
@@ -214,10 +214,10 @@ func (t *translatorRules) load(files []string) (errors []error) {
 	return
 }
 
-// merge takes another translatorRules instance and safely merges its metadata
+// merge takes another TranslatorRules instance and safely merges its metadata
 // into this instance. this replaces yaml marshalling directly into the same
 // instance - as that doesn't do what we want for deep merging.
-func (t *translatorRules) merge(tNew *translatorRules) {
+func (t *TranslatorRules) merge(tNew *TranslatorRules) {
 
 	t.Plural = stringMerge(t.Plural, tNew.Plural)
 

--- a/rules_test.go
+++ b/rules_test.go
@@ -3,11 +3,11 @@ package i18n
 import (
 	"reflect"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestLoad(c *C) {
-	t := new(translatorRules)
+	t := new(TranslatorRules)
 
 	errs := t.load([]string{"does/not/exist/xx.yaml"})
 	c.Check(errs, Not(HasLen), 0)
@@ -51,7 +51,7 @@ func (s *MySuite) TestLoad(c *C) {
 	}
 
 	for _, l := range locales {
-		t := new(translatorRules)
+		t := new(TranslatorRules)
 		errs = t.load([]string{"data/rules/" + l + ".yaml"})
 		c.Check(errs, HasLen, 0)
 	}
@@ -66,7 +66,7 @@ func (s *MySuite) TestLoad(c *C) {
 	}
 
 	for _, l := range locales {
-		t := new(translatorRules)
+		t := new(TranslatorRules)
 		errs = t.load([]string{"data/rules/" + l + ".yaml"})
 		c.Log(l)
 		c.Check(errs, HasLen, 1)

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,7 +1,7 @@
 package i18n
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestLen(c *C) {


### PR DESCRIPTION
Add method to Translator to return dereferenced Rules keeping thread
safety intact. It is less efficient than exposing as a pointer though.

example usage:

translator.Rules().DateTime.FormatNames.Days.Wide.Fri

issue-#6